### PR TITLE
Fix Thermal Nimbus damage roll crash on PF2e v7.12.1

### DIFF
--- a/scripts/actions/thermal-nimbus.js
+++ b/scripts/actions/thermal-nimbus.js
@@ -99,7 +99,7 @@ export class ThermalNimbus {
 
         Chat.rollInlineDamage(
             thermalNimbusFeat,
-            "(floor(@actor.level/2))[@actor.flags.pf2e.kineticist.thermalNimbus]",
+            "(floor(@actor.level/2))[@actor.flags.system.kineticist.thermalNimbus]",
             {
                 "pf2e-kineticists-companion": {
                     "applyDamage": {

--- a/scripts/utils/chat.js
+++ b/scripts/utils/chat.js
@@ -35,11 +35,12 @@ export class Chat {
     static async rollInlineDamage(item, baseFormula, additionalFlags = {}, additionalText = "", additionalRollOptions = []) {
         const html = (await item.getChatData()).description.value;
         const results = $($.parseHTML(html)).find(".inline-roll");
-        const damageDataSet = Array.from(results).find(result => result.dataset.baseFormula === baseFormula).dataset;
-
-        if (!damageDataSet) {
+        const damageElement = Array.from(results).find(result => result.dataset.baseFormula === baseFormula);
+        if (!damageElement) {
+            console.warn("pf2e-kineticists-companion | Could not find inline damage roll matching formula:", baseFormula);
             return;
         }
+        const damageDataSet = damageElement.dataset;
 
         const slug = item.slug;
         const traits = item.system.traits.value;


### PR DESCRIPTION
## Summary
- Update Thermal Nimbus inline damage formula to use `@actor.flags.system` instead of `@actor.flags.pf2e`, matching the current PF2e system's flag path
- Add null-safety to `rollInlineDamage` in `chat.js` so a formula mismatch logs a warning instead of crashing

## Test plan
- In Foundry VTT with PF2e system v7.12.1, activate Thermal Nimbus stance in combat
- Advance turns so an enemy starts their turn in the aura
- Confirm damage rolls automatically without console errors
- Confirm damage triggers when an enemy moves into the aura on their turn

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.6)